### PR TITLE
Feature/channel separation

### DIFF
--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -12,34 +12,18 @@ RUN npm run build
 
 # Installation des dépendances de production uniquement
 RUN npm ci --only=production --ignore-scripts \
-    && mv ./src/config.yaml.dist ./src/config.yaml \
+    && [ -f ./src/config.yaml ] || cp ./src/config.yaml.dist ./src/config.yaml \
     && npm prune --production
 
-FROM debian:bullseye-slim
-
-# Création de l'utilisateur node avant l'installation des paquets
-RUN groupadd --gid 1000 node \
-    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+FROM node:18-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    curl \
-    gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
-    && curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb [arch=$(dpkg --print-architecture)] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        nodejs \
-        google-chrome-stable \
-    && apt-get purge -y --auto-remove curl gnupg \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /attachments \
     && chmod 777 /attachments
 
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome \
-    NODE_ENV=production
+ENV NODE_ENV=production
 
 COPY --from=builder /usr/src/app/dist ./dist
 COPY --from=builder /usr/src/app/node_modules ./node_modules

--- a/src/clients/ai-client.ts
+++ b/src/clients/ai-client.ts
@@ -42,6 +42,7 @@ export default class AIClient extends EventEmitter implements AIClientType {
 
   private extractResponseTagContent(text: string): string {
     if (!text) return '';
+    console.log('Message from AI', text);
     const match = text.match(/<response>([\s\S]*?)<\/response>/i);
     return match ? match[1].trim() : text;
   }

--- a/src/clients/ai-clients/flowise-client.ts
+++ b/src/clients/ai-clients/flowise-client.ts
@@ -153,6 +153,7 @@ export default class FlowiseClient extends EventEmitter implements AIClientType 
         question: lastMessage.content,
         overrideConfig: {
           agentName: ConfigManager.config.discord.botName,
+          sessionId: channelId,
           vars: {
             user_prompt: systemPrompt
           }

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -152,11 +152,14 @@ export default class ConfigManager {
     process.env.AI_PROMPT || configValues.AIPrompt || 'You are a nice assistant in a discord server';
 
   private triggerWords: string[] = (() => {
+    const normalize = (arr: string[]) =>
+      Array.from(new Set(arr.map(w => String(w).trim().toLowerCase()).filter(Boolean)));
+
     if (process.env.TRIGGER_WORDS) {
-      return process.env.TRIGGER_WORDS.split(',');
+      return normalize(process.env.TRIGGER_WORDS.split(','));
     }
     if (configValues.triggerWords && Array.isArray(configValues.triggerWords)) {
-      return configValues.triggerWords;
+      return normalize(configValues.triggerWords);
     }
     console.warn('No trigger words defined. Using an empty array.');
     return [];
@@ -301,7 +304,7 @@ export default class ConfigManager {
     metrics: this.metricsConfig,
     youtubeTranscript: this.youtubeTranscriptConfig,
     puppeteer: {
-      active: process.env.PUPPETEER_ACTIVE === 'true' || configValues.puppeteer?.active || true,
+      active: process.env.PUPPETEER_ACTIVE === 'true' || configValues.puppeteer?.active || false,
       timeout: process.env.PUPPETEER_TIMEOUT ? parseInt(process.env.PUPPETEER_TIMEOUT) : configValues.puppeteer?.timeout || 120000
     },
     moderation: this.moderationConfig,

--- a/src/events/message-create.ts
+++ b/src/events/message-create.ts
@@ -158,13 +158,15 @@ export default class MessageCreate extends EventDiscord {
     const botId = this.discordClient.user?.id;
     const contentLower = message.content.toLowerCase();
     const triggerWords = (this.config.triggerWords || []);
-    const configBotName = this.config.discord.botName?.toLowerCase();
+    const configuredName = (this.config.discord.botName || (this.config as any).botName)?.toLowerCase();
 
-    const mentionMatch = !!botId && message.mentions?.users?.has(botId);
-    const botNameMatch = !!configBotName && contentLower.includes(configBotName);
-    const triggerWordMatch = triggerWords.some((word) => contentLower.includes(word));
+    const mentionByObject = !!botId && message.mentions?.users?.has(botId);
+    const mentionByText = !!botId && new RegExp(`<@!?${botId}>`).test(message.content);
+    const mentionMatch = Boolean(mentionByObject || mentionByText);
+    const botNameMatch = !!configuredName && contentLower.includes(configuredName);
+    const triggerWordMatch = triggerWords.some((word) => contentLower.includes(String(word).toLowerCase()));
 
-    return Boolean(mentionMatch || botNameMatch || triggerWordMatch);
+    return mentionMatch || botNameMatch || triggerWordMatch;
   }
 
   private setupEventListeners(): void {

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -6,7 +6,24 @@ const tools: AITool[] = [];
 toolList.forEach((toolClass) => {
   const instance = new toolClass();
   if (instance.isActivated) {
-    tools.push(instance.buildTool());
+    const built = instance.buildTool();
+    const originalFn = built.function.function;
+    built.function.function = async (...args: any[]) => {
+      try {
+        const result = await originalFn(...args);
+        if (typeof result === 'string') return result;
+        try {
+          return JSON.stringify(result ?? { success: false, error: 'Empty tool result' });
+        }
+        catch {
+          return String(result);
+        }
+      }
+      catch (err: any) {
+        return JSON.stringify({ success: false, error: err?.message || 'Tool execution failed' });
+      }
+    };
+    tools.push(built);
   }
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,7 +11,6 @@ import SerpSearchTool from './serp-search-tool';
 import StableDiffusionTool from './stablediffusion-tool';
 import GiphyTool from './giphy-tool';
 import YoutubeTranscriptTool from './youtube-transcript-tool';
-import PuppeteerTool from './puppeteer-tool';
 import TradingChartTool from './trading-chart-tool';
 const toolList: (typeof AbstractTool)[] = [
   DallETool,
@@ -26,7 +25,6 @@ const toolList: (typeof AbstractTool)[] = [
   FluxGeneratorTool,
   StableDiffusionTool,
   YoutubeTranscriptTool,
-  PuppeteerTool,
   TradingChartTool
 ];
 

--- a/src/utils/ai-prompt-builder.ts
+++ b/src/utils/ai-prompt-builder.ts
@@ -21,11 +21,6 @@ Embody this persona completely: tone, knowledge scope, language style, and behav
 ### Message Processing Logic
 **Input Format**: ${'`'}username: message content [attachment_url]${'`'}
 
-**Critical: Image Detection Protocol**
-- IF trigger message contains ${'`'}[Attachments: image.xxx]${'`'} or any image URL → IMMEDIATELY use image_analysis_tool
-- This happens BEFORE any other processing - images are ALWAYS analyzed first
-- NEVER respond to image-related queries without analyzing the image first
-
 **Smart Context Analysis**:
 1. **Identify Trigger**: The LAST message triggered you - this user needs a response
 2. **Parse Conversation Flow**: 
@@ -37,11 +32,12 @@ Embody this persona completely: tone, knowledge scope, language style, and behav
    - Direct answer to trigger user
    - Reference relevant context when it enhances your response
    - Ignore conversations that don't involve you unless contextually relevant
+   - If you cannot do something (analyze image, analyze crypto chart, go to the website) because user is not subscribed to the MEGA plan, just say you cannot do it and offer to search for latest info
 
 ### Conversation Context Patterns
-- **Thread Continuation**: User references "that video", "the image", "what we discussed" → Look back for context
+- **Thread Continuation**: User references "what we discussed" → Look back for context
 - **Multi-User Dynamics**: Track who shared what, ongoing debates, collaborative tasks
-- **Media References**: Images, YouTube links, charts mentioned in last 10 messages are relevant context
+- **Media References**: Images, YouTube links, charts mentioned in last messages are relevant context
 - **Bot Interactions**: Notice if other bots responded recently - avoid redundancy
 
 ## Autonomous Tool Decision System
@@ -55,11 +51,6 @@ Embody this persona completely: tone, knowledge scope, language style, and behav
 
 **STEP 2 - What type of information is needed?**
 
-**Image Present in Trigger Message** → MANDATORY image_analysis_tool:
-- ANY message with ${'`'}[Attachments: image.xxx]${'`'} or image URL requires image analysis FIRST
-- Analyze image, then respond based on both image content and user question
-- This is MANDATORY regardless of question type
-
 **Real-time/Recent Data** → AUTO-USE perplexity_tool:
 - News, current events, market prices, weather
 - "What's happening with [topic] today/recently?"
@@ -67,10 +58,8 @@ Embody this persona completely: tone, knowledge scope, language style, and behav
 - Any query about events after January 2025
 
 **Visual Content** → AUTO-USE appropriate tool:
-- ANY image attachment in trigger message → ALWAYS use image_analysis_tool first
 - User shares YouTube link → YoutubeTranscript  
 - "Create/generate/draw/show me an image" → flux_images
-- "Analyze [stock/crypto] chart" → chartAnalysis
 
 **Knowledge Gaps** → AUTO-USE perplexity_tool:
 - User asks about specific people/companies I don't know
@@ -89,7 +78,11 @@ If I can give 80%+ accurate answer → Respond, then offer to search for latest 
 **Multi-Tool Workflows**:
 - YouTube link shared → Get transcript → Answer based on content
 - "Research [topic] and create visualization" → Search → Generate image
-- Image with text + questions → Analyze image → Search for related info if needed
+
+**Limitations**:
+- I cannot analyze image because user is not subscribed to the MEGA plan
+- I cannot use analyze crypto chart because user is not subscribed to the MEGA plan
+
 
 ## Response Intelligence
 
@@ -108,7 +101,6 @@ If I can give 80%+ accurate answer → Respond, then offer to search for latest 
 ## Autonomous Behaviors
 
 ### Auto-Triggers (No Permission Needed)
-- **ANY image attachment in trigger message** → Analyze with image_analysis_tool FIRST, always
 - YouTube links mentioned → Fetch transcript
 - Requests for recent/current info → Search immediately
 - Creative requests → Generate images  

--- a/src/utils/ai-prompt-builder.ts
+++ b/src/utils/ai-prompt-builder.ts
@@ -1,11 +1,13 @@
 export class AIPromptBuilder {
-  constructor(
-    private prompt: string
-  ) {}
+  private prompt: string;
+
+  constructor(prompt: string) {
+    this.prompt = prompt;
+  }
 
   createCompletionPrompt(): string {
-    return `# Autonomous Discord Bot System Prompt
 
+    return `
 You are an autonomous Discord bot with a custom personality. Current date: ${new Date().toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' })}
 
 ## Your Identity
@@ -17,10 +19,10 @@ Embody this persona completely: tone, knowledge scope, language style, and behav
 ## Discord Intelligence System
 
 ### Message Processing Logic
-**Input Format**: ${"`"}username: message content [attachment_url]${"`"}
+**Input Format**: ${'`'}username: message content [attachment_url]${'`'}
 
 **Critical: Image Detection Protocol**
-- IF trigger message contains ${"`"}[Attachments: image.xxx]${"`"} or any image URL → IMMEDIATELY use image_analysis_tool
+- IF trigger message contains ${'`'}[Attachments: image.xxx]${'`'} or any image URL → IMMEDIATELY use image_analysis_tool
 - This happens BEFORE any other processing - images are ALWAYS analyzed first
 - NEVER respond to image-related queries without analyzing the image first
 
@@ -54,7 +56,7 @@ Embody this persona completely: tone, knowledge scope, language style, and behav
 **STEP 2 - What type of information is needed?**
 
 **Image Present in Trigger Message** → MANDATORY image_analysis_tool:
-- ANY message with ${"`"}[Attachments: image.xxx]${"`"} or image URL requires image analysis FIRST
+- ANY message with ${'`'}[Attachments: image.xxx]${'`'} or image URL requires image analysis FIRST
 - Analyze image, then respond based on both image content and user question
 - This is MANDATORY regardless of question type
 
@@ -128,6 +130,20 @@ If I can give 80%+ accurate answer → Respond, then offer to search for latest 
 - ❌ Never break character or discuss being an AI assistant
 
 ## Output Protocol
-Respond as your persona would, with tool results seamlessly integrated. No meta-commentary, no process explanations, just intelligent, contextual, helpful responses that feel natural to the Discord conversation flow.`;
+Respond as your persona would, with tool results seamlessly integrated. No meta-commentary, no process explanations, just intelligent, contextual, helpful responses that feel natural to the Discord conversation flow.
+
+Output Formatting (MANDATORY)
+
+- Wrap only the final, user-facing message to be sent in Discord inside the tags <response>...</response>.
+- Do not include any analysis, planning, tool outputs, or reasoning inside the <response>...</response> tags.
+- If you include any reasoning or notes, they must be outside the <response>...</response> tags or omitted entirely.
+- The content inside <response>...</response> must be concise, persona-consistent, and ready to send as-is to Discord.
+
+Example final output:
+
+<response>
+Your final answer to the user, exactly as it should appear in Discord.
+</response>
+`;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "noUnusedParameters": true,
     "strictPropertyInitialization": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds per-channel Discord send queuing and typing loop, enforces <response> tag output parsing, hardens tool/OpenAI handling, normalizes trigger words, removes Puppeteer/Chrome, and switches Docker to node:18-slim.
> 
> - **Discord messaging**:
>   - Per-channel send queue (`enqueueSend`) to serialize replies; adds short delays between chunks.
>   - Continuous typing loop during AI processing; safer logging via `Logger`.
>   - Safer replies (`allowedMentions: { parse: [] }`) and fallback from `reply` to `send`.
>   - Moderation early-exit if message was deleted; improved mention detection (ID, name, trigger words).
> - **AI/prompt pipeline**:
>   - `AIClient`: parses and returns only content within `<response>...</response>`; types improved.
>   - Prompt builder: mandates wrapping final output in `<response>` tags; reorganized guidance and limitations.
>   - OpenAI client: stringifies non-string contents and tool results; typed tool responses; robust follow-up handling.
>   - Flowise client: includes `sessionId` (channelId) in `overrideConfig`.
>   - Tools manager: wraps tools to always return strings and catch errors.
> - **Config**:
>   - Normalizes `triggerWords`; defaults `puppeteer.active` to `false`.
> - **Tools**:
>   - Removes `PuppeteerTool` from registry.
> - **Docker**:
>   - Switches runtime to `node:18-slim`; drops Chrome/Puppeteer deps and related env; safer `config.yaml` copy.
> - **Build/TS**:
>   - Adds Node types to `tsconfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a7e6e2f689246f8c0bc97fbe0cf73978013deb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->